### PR TITLE
Issue-5: Reliable order for scan-tree.

### DIFF
--- a/sphinx_gherkindoc/files.py
+++ b/sphinx_gherkindoc/files.py
@@ -52,11 +52,11 @@ def _not_hidden(name: str) -> bool:
 def _wanted_source_files(files: Iterable, exclude_pattern_list: Iterable) -> List[str]:
     """Get list of wanted sorce files, excluding unwanted files."""
     wanted_files = filter(_is_wanted_file, files)
-    return [
+    return sorted(
         a_file
         for a_file in wanted_files
         if not _is_excluded(a_file, exclude_pattern_list)
-    ]
+    )
 
 
 def scan_tree(

--- a/sphinx_gherkindoc/files.py
+++ b/sphinx_gherkindoc/files.py
@@ -84,6 +84,10 @@ def scan_tree(
         if not private:
             dirs[:] = filter(_not_private, dirs)
 
+        # Make recursion predictable by sorting directory entries since
+        # os.walk doesn't make any guarantees about the order it uses.
+        dirs.sort()
+
         me_path = pathlib.Path(me)
         result.append(
             DirData(

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -124,7 +124,7 @@ def test_wanted_source_files():
 
 
 def test_wanted_source_files_empty_exclude():
-    wanted_files = ["one.feature", "two.md", "subdir/three.feature"]
+    wanted_files = ["one.feature", "subdir/three.feature", "two.md"]
     unwanted_files = ["four.py"]
     assert files._wanted_source_files(wanted_files + unwanted_files, []) == wanted_files
 
@@ -167,7 +167,7 @@ def test_scan_tree_relative():
     relative_path = pathlib.Path("tests")
     expected_data = [
         files.DirData(
-            relative_path.resolve(), ["tests"], [], ["tags.feature", "basic.feature"]
+            relative_path.resolve(), ["tests"], [], ["basic.feature", "tags.feature"]
         )
     ]
     assert files.scan_tree(relative_path, False, []) == expected_data

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -146,18 +146,18 @@ def test_scan_tree(tree):
 
 def test_scan_tree_private(tree):
     expected_data = [
-        files.DirData(tree, ["root0"], ["subdir", "_private_dir"], ["test.feature"]),
+        files.DirData(tree, ["root0"], ["_private_dir", "subdir"], ["test.feature"]),
+        files.DirData(tree / "_private_dir", ["root0", "_private_dir"], [], []),
         files.DirData(
             tree / "subdir", ["root0", "subdir"], [], ["another_test.feature"]
         ),
-        files.DirData(tree / "_private_dir", ["root0", "_private_dir"], [], []),
     ]
     assert files.scan_tree(tree, True, []) == expected_data
 
 
 def test_scan_tree_exclude(tree):
     expected_data = [
-        files.DirData(tree, ["root0"], ["subdir", "_private_dir"], ["test.feature"]),
+        files.DirData(tree, ["root0"], ["_private_dir", "subdir"], ["test.feature"]),
         files.DirData(tree / "_private_dir", ["root0", "_private_dir"], [], []),
     ]
     assert files.scan_tree(tree, True, ["*subdir*"]) == expected_data


### PR DESCRIPTION
Make scantree visit subdirectories in alphabetical order so
that the traversal is both predictable and stable over separate runs.

This is a PRE-COFFEE PR, so please don't just surf it and approve.
I think we had all been using Macs before, and when I tried to run the tests last night on my Ubuntu box, I found the failures (as per #5 ). Given that `os.walk` never promised any particular ordering of how it walks the directory tree, `scan_tree` didn't either.

But another valid response to #5 could be to fix the tests so that they don't care what the ordering is.
