### PR TITLE
Enhancement: TravisCI-Slack Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,29 @@
 language: python
 python:
-  - "3.6"
-
+- '3.6'
 branches:
   only:
-    - master
-
+  - master
 before_install:
-  - sudo apt-get update
-  - sudo apt-get install graphviz
-  - pip install poetry
-
+- sudo apt-get update
+- sudo apt-get install graphviz
+- pip install poetry
 install:
-  - ./env_setup.py
-
+- "./env_setup.py"
 script:
-  - ./self_check.py
-  - ./bin/build_docs.py
-
+- "./self_check.py"
+- "./bin/build_docs.py"
 before_deploy:
-  - poetry config http-basic.pypi $PYPI_USER $PYPI_PASS
-  - poetry build
-
+- poetry config http-basic.pypi $PYPI_USER $PYPI_PASS
+- poetry build
 deploy:
-  - provider: pages
-    skip_cleanup: true
-    github_token: $GH_TOKEN
-    local_dir: docs/
-  - provider: script
-    script: poetry publish
-    skip_cleanup: true
+- provider: pages
+  skip_cleanup: true
+  github_token: "$GH_TOKEN"
+  local_dir: docs/
+- provider: script
+  script: poetry publish
+  skip_cleanup: true
+notifications:
+  slack:
+    secure: irfpNAUOCEd5CuXPL57jieEgMmpiRNHEHudLDDMD2icq+9PMG3XXo4IFRtVVoVM9QZwIeGIpSYMbN6wl76+pee8ezfMe1/xmVSQ1g33ceZhqONhLWgH7mabKls2Vf3IZAeWQfamyDV9AcyD49bL92UX34XxQJ1yJ/X6z+qxxmUWNNDcRy/Ab6puPKTTJsWw47KTFvsBy1zCOGpBIMWA1tZOfBeZ7puk1pdUSPl9KgNCPCN8A/GzaiywnTuVmYry+j90wB/44WZ5SYItoHM1lz4RW3cxhbwwaok2b5Xf2J0X34hGuFgDb3TN863BglMVdNUfozL85GNy/bf4wAmlgjiR9Q31gfQprp37vvkT9kX0KkAt6eDaKY4En9ppuNMG2dvyALS52bKpAoM6La3Rc3PrmZRmSTmV/uCTDseCVwZgVF8WuR+LkS/kOHoZZSf5AHrG/AODIr3cOPWwrtpSc/loHKrQN9QF9WEhg7KjDBeEUrRs8yrK4mVOXij94WK59+IUaKclPI5JBAa363IiZrbWNquJmKxU4e3Wc7sLLgY7UZ24Xloo1mfAAJuorsKUp2QH3K6S+xim7RSIsyKI9405oHBB8msG47HZZC6nKsMCDrdnnUSsfboFVvfUw4sGwsehvAR5ANzDRuS1iaSymzM7pQLQudM1Jh8np0sd1pmo=


### PR DESCRIPTION
Have TravisCI post updates in Slack like GitHub does.

Note: I utilized the official travis CLI to encrypt the notification
string based on their recommendations since the token that would be
included in the file is only semi-secret. However, as a result, it also
auto-linted the file.