### PR TITLE
Fix: background glossary lines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sphinx_gherkindoc"
-version = "3.2.6"
+version = "3.2.7"
 description = "A tool to convert Gherkin into Sphinx documentation"
 authors = ["Lewis Franklin <lewis.franklin@gmail.com>", "Doug Philips <dgou@mac.com>"]
 readme = "README.rst"

--- a/sphinx_gherkindoc/glossary.py
+++ b/sphinx_gherkindoc/glossary.py
@@ -11,7 +11,7 @@ class GlossaryEntry(object):
 
     def __init__(self) -> None:
         self.step_set: Set[str] = set()
-        self.locations: DefaultDict[pathlib.Path, list] = defaultdict(list)
+        self.locations: DefaultDict[pathlib.Path, set] = defaultdict(set)
 
     def add_reference(
         self, step_name: str, filename: pathlib.Path, line_number: int
@@ -27,7 +27,7 @@ class GlossaryEntry(object):
         """
 
         self.step_set.add(step_name)
-        self.locations[filename].append(line_number)
+        self.locations[filename].add(line_number)
 
     def tuple_len(self) -> Tuple[int, int]:
         """Get the length for each location and the number of associated steps."""

--- a/tests/test_glossary.py
+++ b/tests/test_glossary.py
@@ -39,7 +39,7 @@ def test_glossary_entry_add_reference(entry):
     feature_file = pathlib.Path("filename.feature")
     entry.add_reference("A step", feature_file, 12)
     assert entry.step_set == {"A step"}
-    assert dict(entry.locations) == {feature_file: [12]}
+    assert dict(entry.locations) == {feature_file: {12}}
 
 
 def test_glossary_entry_tuple_len(entry):


### PR DESCRIPTION
Ran across an issue where background steps were displaying the same line number repeatedly for each scenario in which the background step was active. This is an attempt to fix that.

NOTE: If we have any users that use the glossary logic externally, this does change the API slightly due to storing line numbers in a set rather than a list, so that might either mean a change in approach here or at least a larger version bump.