### PR TITLE
Allow for dynamic display names based on dir names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sphinx_gherkindoc"
-version = "3.3.1"
+version = "3.3.3"
 description = "A tool to convert Gherkin into Sphinx documentation"
 authors = ["Lewis Franklin <lewis.franklin@gmail.com>", "Doug Philips <dgou@mac.com>"]
 readme = "README.rst"

--- a/sphinx_gherkindoc/cli.py
+++ b/sphinx_gherkindoc/cli.py
@@ -52,7 +52,12 @@ def process_args(
             continue
 
         toc_file = toctree(
-            current.path_list, new_subdirs, current.files, maxtocdepth, root_path
+            current.path_list,
+            new_subdirs,
+            current.files,
+            maxtocdepth,
+            root_path,
+            args.display_name_from_dir,
         )
         # Check to see if we are at the last item to be processed
         # (which has already been popped)
@@ -182,6 +187,15 @@ def main() -> None:
         " parameter, the tag."
     )
     parser.add_argument("--url-from-tag", help=url_help)
+    display_name_from_dir_help = (
+        "A library and method name to call to convert a directory name into a"
+        " display name. The string should be <library>:<method_name>"
+        " and it should accept a single string parameter, the directory name."
+        " The output of this function will be the same as creating"
+        " display_name.txt files for each directory, based on the directory name."
+        " Any display_name.txt files that exist will take precedence over this flag."
+    )
+    parser.add_argument("--display-name-from-dir", help=display_name_from_dir_help)
 
     args = parser.parse_args()
 

--- a/sphinx_gherkindoc/utils.py
+++ b/sphinx_gherkindoc/utils.py
@@ -1,4 +1,5 @@
 """Generic utils used throughout the module."""
+import importlib
 import pathlib
 import string
 from typing import List, Optional
@@ -135,7 +136,11 @@ class SphinxWriter(object):
             f.write("".join(self._output))
 
 
-def display_name(path: pathlib.Path, package_name: Optional[str] = "") -> str:
+def display_name(
+    path: pathlib.Path,
+    package_name: Optional[str] = "",
+    display_name_from_dir: Optional[str] = None,
+) -> str:
     """
     Create a human-readable name for a given project.
 
@@ -146,6 +151,7 @@ def display_name(path: pathlib.Path, package_name: Optional[str] = "") -> str:
     Args:
         path: Path for searching
         package_name: Sphinx-style, dot-delimited package name (optional)
+        display_name_from_dir: The
 
     Returns:
         A display name for the provided path
@@ -155,5 +161,13 @@ def display_name(path: pathlib.Path, package_name: Optional[str] = "") -> str:
     if name_path.exists():
         with open(name_path, "r") as name_fo:
             return name_fo.readline().rstrip("\r\n")
+
     raw_name = package_name.split(".")[-1] if package_name else path.name
+
+    if display_name_from_dir:
+        module_name, function_name = display_name_from_dir.split(":", maxsplit=1)
+        conversion_func_module = importlib.import_module(module_name)
+        conversion_func = getattr(conversion_func_module, function_name)
+        return conversion_func(raw_name)
+
     return string.capwords(raw_name.replace("_", " "))

--- a/sphinx_gherkindoc/writer.py
+++ b/sphinx_gherkindoc/writer.py
@@ -51,6 +51,7 @@ def toctree(
     files: List[str],
     maxtocdepth: int,
     root_path: pathlib.Path,
+    display_name_from_dir: Optional[str] = None,
 ) -> SphinxWriter:
     """
     Return a SphinxWriter for one level of a directory tree.
@@ -85,7 +86,13 @@ def toctree(
 
     if need_header:
         # We're just adding a boiler plate heading.
-        of.create_section(1, display_name(root_path.joinpath(*path_list)))
+        of.create_section(
+            1,
+            display_name(
+                root_path.joinpath(*path_list),
+                display_name_from_dir=display_name_from_dir,
+            ),
+        )
 
     of.add_output(".. toctree::")
     of.add_output(f":maxdepth: {maxtocdepth}", line_breaks=2, indent_by=INDENT_DEPTH)


### PR DESCRIPTION
This is an interesting idea that I think will be useful!

`display_name.txt` is a great feature. Lets you make the docs titles look nice. But what if there is a pattern you want to follow based on the directory name? You can currently manually create a `display_name.txt` file in every directory, but then you have to remember to do that every time new directories are added.

This PR proposes a solution where you pass in a module/function pair that will translate directory names into display names. It works the same way that the `--url-from-tag` flag works, and it expects the value to be in the same format.

NOTE: There's weren't any unit tests for the `--url-from-tag` flag (see the code coverage). That isn't necessarily an excuse to not add them here, but perhaps it can be a FF to add tests for both. Either way I wanted to get this idea out there for early feedback, and I'll look into adding the tests nonetheless.