### PR TITLE
Pre commit hook fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,5 +21,3 @@ repos:
       rev: v0.770
       hooks:
           - id: mypy
-            exclude: ^((tests|bin)\/)?[\w-]+\.py$
-            args: ["--disallow-untyped-defs", "--ignore-missing-imports"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
     - repo: https://github.com/ambv/black
-      rev: stable
+      rev: 19.10b0
       hooks:
           - id: black
             language_version: python3
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v2.2.3
+    - repo: https://gitlab.com/pycqa/flake8
+      rev: 3.7.9
       hooks:
           - id: flake8
             exclude: ^build/*
@@ -18,7 +18,8 @@ repos:
                 - pep8-naming
                 - pydocstyle<4.0.0
     - repo: https://github.com/pre-commit/mirrors-mypy
-      rev: v0.701
+      rev: v0.770
       hooks:
           - id: mypy
-            exclude: tests/data/*
+            exclude: ^((tests|bin)\/)?[\w-]+\.py$
+            args: ["--disallow-untyped-defs", "--ignore-missing-imports"]

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,7 @@
+[mypy]
+# Do not raise errors for imports without typestubs
+ignore_missing_imports = True
+
+[mypy-sphinx_gherkindoc]
+# Require all package defs to be fully type-hinted
+disallow_untyped_defs = True

--- a/sphinx_gherkindoc/glossary.py
+++ b/sphinx_gherkindoc/glossary.py
@@ -33,12 +33,14 @@ class GlossaryEntry(object):
         """Get the length for each location and the number of associated steps."""
         return (len(self.locations), sum(map(len, self.locations.values())))
 
-    def __gt__(self, other) -> bool:
+    def __gt__(self, other: "GlossaryEntry") -> bool:
         """Compare the location and step lenghts for the larger one."""
         return self.tuple_len() > other.tuple_len()
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: object) -> bool:
         """Compare the location and step lengths for equality."""
+        if not isinstance(other, GlossaryEntry):
+            return NotImplemented
         return self.tuple_len() == other.tuple_len()
 
 

--- a/sphinx_gherkindoc/parsers/base.py
+++ b/sphinx_gherkindoc/parsers/base.py
@@ -1,13 +1,14 @@
 """Base classes for parsing."""
+from typing import Any
 
 
 class BaseModel:
     """Base model for parsers."""
 
-    def __init__(self, data):
+    def __init__(self, data: Any):
         self._data = data
 
-    def __getattr__(self, key):
+    def __getattr__(self, key: str) -> Any:
         """Grab attribute from wrapped class, if present.
 
         When inheriting this model,

--- a/sphinx_gherkindoc/parsers/behave.py
+++ b/sphinx_gherkindoc/parsers/behave.py
@@ -44,6 +44,6 @@ class Feature(BehaveModel):
         return [Scenario(s) for s in self._data.scenarios]
 
     @property
-    def examples(self) -> Union[behave.model.Example, List]:
+    def examples(self) -> Union[behave.model.Examples, List]:
         """Supports dummy feature-level examples."""
         return []

--- a/sphinx_gherkindoc/parsers/behave.py
+++ b/sphinx_gherkindoc/parsers/behave.py
@@ -1,4 +1,6 @@
 """Helper functions for writing rST files with behave parser."""
+from typing import List, Optional, Union
+
 import behave.parser
 
 from .base import BaseModel
@@ -8,7 +10,7 @@ class BehaveModel(BaseModel):
     """Custom model for Behave-parsed objects."""
 
     @property
-    def description(self):
+    def description(self) -> Optional[List[str]]:
         """Add some reasonable assumptions about line breaks into descriptions.
 
         Any line that ends in a period will have a newline added for separation.
@@ -33,15 +35,15 @@ class Scenario(BehaveModel):
 class Feature(BehaveModel):
     """Feature model for Behave."""
 
-    def __init__(self, root_path, source_path):
+    def __init__(self, root_path: str, source_path: str):
         self._data = behave.parser.parse_file(source_path)
 
     @property
-    def scenarios(self):
+    def scenarios(self) -> List[Scenario]:
         """Wrap Behave Scenarios to include description processing."""
         return [Scenario(s) for s in self._data.scenarios]
 
     @property
-    def examples(self):
+    def examples(self) -> Union[behave.model.Example, List]:
         """Supports dummy feature-level examples."""
         return []

--- a/sphinx_gherkindoc/parsers/pytest_bdd.py
+++ b/sphinx_gherkindoc/parsers/pytest_bdd.py
@@ -1,13 +1,13 @@
 """Helper functions for writing rST files."""
 from collections import namedtuple
-from typing import List, Literal, Optional, Union
+from typing import List, Optional, Union
 import pathlib
 
 import pytest_bdd.feature
 
 from .base import BaseModel
 
-BlankString = Literal[""]
+BlankString = str
 InlineTable = namedtuple("InlineTable", ["headings", "rows"])
 
 

--- a/sphinx_gherkindoc/writer.py
+++ b/sphinx_gherkindoc/writer.py
@@ -209,7 +209,7 @@ def feature_to_rst(
 
     # Reference link here because it's too long to put inside the function itself.
     # http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#embedded-uris-and-aliases
-    def _url_if_url(url_checker: Optional[Callable], value: str,) -> str:
+    def _url_if_url(url_checker: Optional[Callable], value: str) -> str:
         return url_checker(value) if url_checker else ""
 
     def _value_with_url(value: str, url: str) -> str:


### PR DESCRIPTION
In `pre-commit` config setup:
* Update to a `python3.8`-friendly `mypy` version and require typehints
* limit `mypy` checks to package files (I'm open to persuasion here, but this seemed to be the right place to start requiring hints)
* Move from deprecated `flake8` link to the new standard repo and modern version
* Pin `black` to a version tag (since it often changes significantly between beta releases, and so to ensure consistency in formatting between contributors)

Then, update all files to use now-required typehints.