### PR TITLE
Enhancement: Build docs for subsets of features/scenarios based on tags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -195,6 +195,15 @@ In order to use the parser via command line,
 the ``--url_from-tag`` and ``--display-name-from-dir`` flags should be used.
 The provided string should be be formatted ``<library>:<method_name>``
 
+Filtering Included Features/Scenarios By Tag
+--------------------------------------------
+
+If you'd like to build documentation for only a subset of features/scenarios,
+you can include and exclude them by tags.
+
+Just use the ``--include-tags`` and/or ``--exclude-tags`` flags.
+Run ``sphinx-gherkindoc --help`` for usage info.
+
 Formatting Options
 ------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sphinx_gherkindoc"
-version = "3.4.6"
+version = "3.5.0"
 description = "A tool to convert Gherkin into Sphinx documentation"
 authors = ["Lewis Franklin <lewis.franklin@gmail.com>", "Doug Philips <dgou@mac.com>"]
 readme = "README.rst"

--- a/sphinx_gherkindoc/cli.py
+++ b/sphinx_gherkindoc/cli.py
@@ -126,7 +126,12 @@ def process_args(
                     integrate_background=args.integrate_background,
                     background_step_format=args.background_step_format,
                     raw_descriptions=args.raw_descriptions,
+                    include_tags=args.include_tags,
+                    exclude_tags=args.exclude_tags,
                 )
+                if not feature_rst_file:
+                    continue
+
                 verbose(f'converting "{source_name}" to "{dest_name}"')
                 feature_rst_file.write_to_file(dest_name)
             elif not is_rst_file(a_file):

--- a/sphinx_gherkindoc/cli.py
+++ b/sphinx_gherkindoc/cli.py
@@ -262,6 +262,20 @@ def main() -> None:
             "This allows descriptions to contain rST links, code blocks, etc."
         ),
     )
+    include_exclude_tags_caveat = (
+        "If a feature/scenario has both an exclude and and include tag,"
+        "it will be excluded."
+    )
+    exclude_tags_help = (
+        "Features and scenarios tagged with these exclude tags "
+        "will not be included in the build docs. " + include_exclude_tags_caveat
+    )
+    parser.add_argument("--exclude-tags", help=exclude_tags_help, nargs="*")
+    include_tags_help = (
+        "Only features and scenarios tagged with at least one of these include tags "
+        "will be included in the build docs." + include_exclude_tags_caveat
+    )
+    parser.add_argument("--include-tags", help=include_tags_help, nargs="*")
 
     args = parser.parse_args()
 

--- a/sphinx_gherkindoc/parsers/__init__.py
+++ b/sphinx_gherkindoc/parsers/__init__.py
@@ -1,13 +1,12 @@
 """Sphinx-Gherkindoc Parsers."""
 import importlib
 from pathlib import Path
+from typing import List, Union
 
 try:
     from typing import Protocol
 except ImportError:
     from typing_extensions import Protocol  # type: ignore
-
-from .base import BaseModel
 
 
 parsers = {}
@@ -26,7 +25,33 @@ for file in Path(__file__).parent.glob("*.py"):
     parsers[name] = feature
 
 
-class ExampleClass(Protocol):
-    """Protocol for models that contain examples."""
+class ExamplesTableClass(Protocol):
+    """Protocol for an examples table class model."""
 
-    examples: BaseModel
+    tags: List[str]
+
+
+class StepClass(Protocol):
+    """Protocol for a step class model."""
+
+    name: str
+    keyword: str
+
+
+class ScenarioClass(Protocol):
+    """Protocol for a scenario class model."""
+
+    examples: List[ExamplesTableClass]
+    tags: List[str]
+    steps: List[StepClass]
+
+
+class FeatureClass(Protocol):
+    """Protocol for a feature class model."""
+
+    scenarios: List[ScenarioClass]
+    examples: List[ExamplesTableClass]
+    tags: List[str]
+
+
+ClassWithExamples = Union[FeatureClass, ScenarioClass]

--- a/sphinx_gherkindoc/utils.py
+++ b/sphinx_gherkindoc/utils.py
@@ -5,6 +5,8 @@ from typing import Callable, List, Optional
 
 import sphinx.util
 
+from sphinx_gherkindoc.parsers import ScenarioClass, FeatureClass, ExamplesTableClass
+
 # Increments of how much we indent Sphinx rST content when indenting.
 INDENT_DEPTH = 4
 
@@ -174,3 +176,115 @@ def display_name(
         return dir_display_name_converter(raw_name)
 
     return string.capwords(raw_name.replace("_", " "))
+
+
+def get_all_included_scenarios(
+    feature: FeatureClass,
+    include_tags: List[str] = None,
+    exclude_tags: List[str] = None,
+) -> List[ScenarioClass]:
+    """
+    Get all scenarios to include in the docs based on the include/exclude tags.
+
+    This is designed to match what tests would be run if you ran a test suite
+    with something like this (pytest-bdd format)::
+
+        -m include_this_tag -m "not exclude_this_tag"
+
+    Args:
+        feature: The feature whose scenarios are to be filtered.
+        include_tags: Tags for which scenarios should be included.
+        exclude_tags: Tags for which scenarios should be excluded.
+
+    Returns:
+         All scenarios to include.
+
+    """
+    # If there's no exclude/include logic return all scenarios
+    if not include_tags and not exclude_tags:
+        return feature.scenarios
+
+    include_tags_set = set(include_tags) if include_tags else set()
+    exclude_tags_set = set(exclude_tags) if exclude_tags else set()
+    feature_tags_set = set(feature.tags)
+
+    if feature_tags_set & exclude_tags_set:
+        return []
+
+    # If there are no include tags,
+    # then treat it the same as if the feature has an include tag.
+    # If include tags exist, that will affect whether or not
+    # the scenario needs to have an include tag.
+    feature_has_include_tag = (
+        bool(feature_tags_set & include_tags_set) if include_tags else True
+    )
+
+    included_scenarios = []
+    for scenario in feature.scenarios:
+        scenario_tags_set = set(scenario.tags)
+        scenario_examples = getattr(scenario, "examples", [])
+
+        # If there are no include tags,
+        # then treat it the same as if the scenario has an include tag.
+        # If include tags exist, that will affect whether or not
+        # any examples tables need to have an include tag.
+        # If the feature has an include tag, then the scenario inherits it.
+        scenario_has_include_tag = feature_has_include_tag or (
+            bool(scenario_tags_set & include_tags_set) if include_tags else True
+        )
+
+        included_examples: List[ExamplesTableClass] = []
+        for examples_table in scenario_examples:
+            examples_table_tags_set = set(examples_table.tags)
+            examples_table_has_include_tag = bool(
+                examples_table_tags_set & include_tags_set
+            )
+
+            if any(
+                # Exclude the examples table if:
+                [
+                    # Examples table has an exclude tag
+                    (examples_table_tags_set & exclude_tags_set),
+                    # Neither the scenario,
+                    # nor any scenario outline examples tables
+                    # have an include tag
+                    (
+                        not scenario_has_include_tag
+                        and not examples_table_has_include_tag
+                    ),
+                ]
+            ):
+                continue
+
+            included_examples.append(examples_table)
+
+        all_examples_tables_have_exclude_tag = False
+        if scenario_examples:
+            all_examples_tables_have_exclude_tag = all(
+                (set(examples_table.tags) & exclude_tags_set)
+                for examples_table in scenario_examples
+            )
+
+        at_least_one_examples_table_included = scenario_examples and included_examples
+        if any(
+            # Exclude if:
+            [
+                # Scenario has an exclude tag
+                (scenario_tags_set & exclude_tags_set),
+                # Neither the scenario, nor any scenario examples tables are included
+                (
+                    not scenario_has_include_tag
+                    and not at_least_one_examples_table_included
+                ),
+                # All examples tables in the scenario have at least one exclude tag
+                all_examples_tables_have_exclude_tag,
+            ]
+        ):
+            continue
+
+        # Only include examples tables that are included
+        if scenario_examples:
+            scenario.examples = included_examples
+        included_scenarios.append(scenario)
+
+    return included_scenarios

--- a/sphinx_gherkindoc/writer.py
+++ b/sphinx_gherkindoc/writer.py
@@ -10,7 +10,7 @@ import behave.model_core
 
 from .files import is_rst_file
 from .glossary import step_glossary
-from .parsers import parsers, ExampleClass
+from .parsers import parsers, ClassWithExamples
 from .utils import (
     display_name,
     make_flat_name,
@@ -315,7 +315,7 @@ def feature_to_rst(
                 text(step.text)
 
     def examples(
-        example_source: ExampleClass,
+        example_source: ClassWithExamples,
         example_source_parent: Optional[behave.model.Feature] = None,
     ) -> None:
         tag_sources = [example_source]

--- a/sphinx_gherkindoc/writer.py
+++ b/sphinx_gherkindoc/writer.py
@@ -18,6 +18,7 @@ from .utils import (
     rst_escape,
     SphinxWriter,
     verbose,
+    get_all_included_scenarios,
 )
 
 _keywords = (
@@ -152,7 +153,9 @@ def feature_to_rst(
     integrate_background: bool = False,
     background_step_format: str = "{}",
     raw_descriptions: bool = False,
-) -> SphinxWriter:
+    include_tags: List[str] = None,
+    exclude_tags: List[str] = None,
+) -> Optional[SphinxWriter]:
     """Return a SphinxWriter containing the rST for the given feature file."""
     output_file = SphinxWriter()
 
@@ -359,6 +362,11 @@ def feature_to_rst(
             f" options are: {list(parsers.keys())}"
         )
     feature = feature_class(root_path, source_path)
+
+    included_scenarios = get_all_included_scenarios(feature, include_tags, exclude_tags)
+    if not included_scenarios:
+        return None
+
     section(1, feature)
     description(feature, raw_descriptions=raw_descriptions)
     if feature.examples:
@@ -367,7 +375,7 @@ def feature_to_rst(
         section(2, feature.background)
         steps(feature.background.steps)
         output_file.blank_line()
-    for scenario in feature.scenarios:
+    for scenario in included_scenarios:
         section(2, scenario)
         tags(scenario.tags, feature)
         description(scenario, raw_descriptions=raw_descriptions)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -281,3 +281,224 @@ def test_display_name_dir_converter(display_name_tree):
         )
         == "DISPLAY NAME TEST"
     )
+
+
+# Basic objects with only the attributes needed for `get_all_included_scenarios`
+# Can't use @dataclass since we run tests with older versions of python than 3.7
+class Feature:
+    """Bare minimum test feature class."""
+
+    def __init__(self, tags, scenarios):
+        self.tags = tags
+        self.scenarios = scenarios
+
+
+class Scenario:
+    """Bare minimum test scenario class."""
+
+    def __init__(self, tags, examples):
+        self.tags = tags
+        self.examples = examples
+
+
+class Example:
+    """Bare minimum test examples table class."""
+
+    def __init__(self, tags):
+        self.tags = tags
+
+
+arbitrary_multiple_number = 4
+tagless_scenarios = [
+    Scenario(tags=[], examples=[]) for _ in range(arbitrary_multiple_number)
+]
+feature_tagged_with_a = Feature(scenarios=tagless_scenarios, tags=["a"])
+feature_tagged_with_a_and_b = Feature(scenarios=tagless_scenarios, tags=["a", "b"])
+scenarios_tagged_with_a = [
+    Scenario(tags=["a"], examples=[]) for _ in range(arbitrary_multiple_number)
+]
+scenarios_tagged_with_b = [
+    Scenario(tags=["b"], examples=[]) for _ in range(arbitrary_multiple_number)
+]
+scenarios_tagged_with_a_and_b = [
+    Scenario(tags=["a", "b"], examples=[]) for _ in range(arbitrary_multiple_number)
+]
+examples_tagged_with_a = [Example(tags=["a"]) for _ in range(arbitrary_multiple_number)]
+examples_tagged_with_b = [Example(tags=["b"]) for _ in range(arbitrary_multiple_number)]
+
+
+@pytest.mark.parametrize(
+    "description, feature, include_tags, exclude_tags, expected_scenarios",
+    [
+        # ~ ONLY FEATURE TAGS ~
+        (
+            "Feature is included if no include or exclude tags are provided",
+            feature_tagged_with_a,
+            None,
+            None,
+            feature_tagged_with_a.scenarios,
+        ),
+        (
+            "Feature tagged with an include tag is included",
+            feature_tagged_with_a,
+            ["a"],
+            None,
+            feature_tagged_with_a.scenarios,
+        ),
+        (
+            "Feature tagged with a non-exclude tag is included",
+            feature_tagged_with_a,
+            None,
+            ["b"],
+            feature_tagged_with_a.scenarios,
+        ),
+        (
+            "Feature tagged with an include tag but not an include tag is included",
+            feature_tagged_with_a,
+            ["a"],
+            ["b"],
+            feature_tagged_with_a.scenarios,
+        ),
+        (
+            "Feature tagged with a non-include tag is excluded",
+            feature_tagged_with_a,
+            ["b"],
+            None,
+            [],
+        ),
+        (
+            "Feature tagged with an exclude tag is excluded",
+            feature_tagged_with_a,
+            None,
+            ["a"],
+            [],
+        ),
+        (
+            "Feature tagged with an exclude tag and an include tag is excluded",
+            feature_tagged_with_a_and_b,
+            ["a"],
+            ["b"],
+            [],
+        ),
+        # ~ ONLY SCENARIO TAGS ~
+        (
+            "All scenarios tagged with include are included",
+            Feature([], scenarios_tagged_with_a),
+            ["a"],
+            None,
+            scenarios_tagged_with_a,
+        ),
+        (
+            "All scenarios tagged with exclude cause no included scenarios",
+            Feature([], scenarios_tagged_with_a),
+            None,
+            ["a"],
+            [],
+        ),
+        (
+            "All scenarios tagged with both include and exclude "
+            "cause no included scenarios",
+            Feature([], scenarios_tagged_with_a_and_b),
+            ["a"],
+            ["b"],
+            [],
+        ),
+        (
+            "Only scenarios tagged with an include tag are included",
+            Feature([], scenarios_tagged_with_a + scenarios_tagged_with_b),
+            ["a"],
+            None,
+            scenarios_tagged_with_a,
+        ),
+        (
+            "Only scenarios tagged with an exclude tag are excluded",
+            Feature([], scenarios_tagged_with_a + scenarios_tagged_with_b),
+            None,
+            ["a"],
+            scenarios_tagged_with_b,
+        ),
+        # ~ FEATURE & SCENARIO TAGS ~
+        (
+            "When a feature is tagged with an include tag, "
+            "only scenarios tagged with an exclude tag are excluded",
+            Feature(["a"], scenarios_tagged_with_a + scenarios_tagged_with_b),
+            None,
+            ["b"],
+            scenarios_tagged_with_a,
+        ),
+        (
+            "When a feature is tagged with exclude tag, "
+            "but scenarios have include tag, "
+            "then no scenarios are included",
+            Feature(["b"], scenarios_tagged_with_a + scenarios_tagged_with_b),
+            ["a"],
+            ["b"],
+            [],
+        ),
+        # ~ EXAMPLES TABLES TAGS ~
+        (
+            "Specific examples tables can be excluded",
+            Feature(
+                tags=["a"],
+                scenarios=[
+                    Scenario(
+                        tags=[],
+                        examples=examples_tagged_with_a + examples_tagged_with_b,
+                    )
+                ],
+            ),
+            ["a"],
+            ["b"],
+            [Scenario(tags=[], examples=examples_tagged_with_a)],
+        ),
+        (
+            "Scenarios with include tag, but with all examples tables "
+            "having an exclude tag will exclude the whole scenario",
+            Feature(
+                tags=["a"],
+                scenarios=[Scenario(tags=[], examples=examples_tagged_with_b)],
+            ),
+            ["a"],
+            ["b"],
+            [],
+        ),
+        (
+            "Scenario is included if only an examples table has an include tag",
+            Feature(
+                tags=[],
+                scenarios=[
+                    Scenario(
+                        tags=[],
+                        examples=examples_tagged_with_a + examples_tagged_with_b,
+                    )
+                ],
+            ),
+            ["a"],
+            ["b"],
+            [Scenario(tags=[], examples=examples_tagged_with_a)],
+        ),
+    ],
+)
+def test_get_all_included_scenarios(
+    description, feature, include_tags, exclude_tags, expected_scenarios
+):
+    actual_scenarios = utils.get_all_included_scenarios(
+        feature, include_tags, exclude_tags
+    )
+    err_msg = "Test Failed: {}".format(description)
+
+    # We can't just do `assert actual_scenarios == expected_scenarios`,
+    # because sometimes they are technically different test objects,
+    # but they have the same len, values, etc.
+    # It would be hard to set that up in the tests because the
+    # `utils.get_all_included_scenarios` function can mutate scenario objects.
+
+    assert len(actual_scenarios) == len(expected_scenarios), err_msg
+
+    for i in range(len(actual_scenarios)):
+        expected_scenario = expected_scenarios[i]
+        actual_scenario = actual_scenarios[i]
+
+        assert actual_scenario.tags == expected_scenario.tags, err_msg
+        if hasattr(expected_scenario, "tags"):
+            assert actual_scenario.tags == expected_scenario.tags, err_msg

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -132,3 +132,16 @@ def test_feature_to_rst_tags_converted_to_url(tags_feature_file):
         tags_feature_file, tags_feature_file.parent, get_url_from_tag=get_url_from_tag
     )
     assert results._output == rst_output.tags_rst_with_urls
+
+
+def test_filter_by_tags_logic_is_triggered(tags_feature_file):
+    # All the variations are tested in test_utils.test_get_all_included_scenarios,
+    # so this just makes sure that logic get triggered within the writer.py module.
+    results = writer.feature_to_rst(
+        tags_feature_file,
+        tags_feature_file.parent,
+        # An include tag that should cause the feature to be excluded,
+        # meaning the include/exclude helper has indeed been triggered.
+        include_tags=["some-tag-no-scenario-or-feature-has"],
+    )
+    assert results is None


### PR DESCRIPTION
### What & Why
A new feature! Hopefully the docs and tests are clear enough to describe the behavior, but here's what it is, and why it can be useful:

This change let's you build documentation for only a subset of your feature files, based on tags. You can provide include tags for only including features/scenarios with those tags, and exclude tags for excluding features/scenarios with those tags.

This is particularly useful for part of my workflow because we want to use sphinx-gherkindoc to show all of the tests from a specific test run. Like if a test run passes, look here to see the coverage of all the behavior that has been validated. So in that case, we would exclude tests that were skipped or expected to fail. sphinx-gherkindoc makes it nice to look at a group of features/scenarios, so it can also make it nice to look at a specific subset of features/scenarios.

### Implementation/Review Notes
The thing that complicated this the most was scenario examples tables. Since examples tables can be tagged, you want to filter those out as well. So an include tag could be on the feature, scenarios, or only the examples table, and that should be included.

There were a bunch of cases I tried to think about. I did a true TDD style where I wrote out all the test cases to describe the behavior expectations and then implemented to make that work. Besides looking at the source code itself, reviewing the test cases for possible missing edge cases will be great. pytest does show that the code coverage for that logic is 100% but that doesn't mean there isn't code that should be there to handle a special case.

The logic is pretty long and possibly confusing (even for me having written it). I tried to refactor as best I could to organize it in the last commit, but I'm definitely happy to get suggestions for how it could be cleaner.