### PR TITLE
Ensure TOC tree matches actual files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sphinx_gherkindoc"
-version = "3.5.0"
+version = "3.5.1"
 description = "A tool to convert Gherkin into Sphinx documentation"
 authors = ["Lewis Franklin <lewis.franklin@gmail.com>", "Doug Philips <dgou@mac.com>"]
 readme = "README.rst"

--- a/sphinx_gherkindoc/cli.py
+++ b/sphinx_gherkindoc/cli.py
@@ -94,23 +94,8 @@ def process_args(
         if args.dry_run:
             continue
 
-        toc_file = toctree(
-            current.path_list,
-            new_subdirs,
-            current.files,
-            maxtocdepth,
-            root_path,
-            dir_display_name_converter=dir_display_name_converter,
-        )
-        # Check to see if we are at the last item to be processed
-        # (which has already been popped)
-        # to write the asked for master TOC file name.
-        if not work_to_do:
-            toc_filename = top_level_toc_filename
-        else:
-            toc_filename = output_path / make_flat_name(current.path_list, is_dir=True)
-        toc_file.write_to_file(toc_filename)
-
+        # Make a copy of the list, as some items may be removed.
+        files_for_toc = list(current.files)
         for a_file in current.files:
             a_file_list = current.path_list + [a_file]
             source_name = pathlib.Path().joinpath(*a_file_list)
@@ -130,6 +115,7 @@ def process_args(
                     exclude_tags=args.exclude_tags,
                 )
                 if not feature_rst_file:
+                    files_for_toc.remove(a_file)
                     continue
 
                 verbose(f'converting "{source_name}" to "{dest_name}"')
@@ -140,6 +126,23 @@ def process_args(
                 )
                 verbose(f'copying "{source_name}" to "{dest_name}"')
                 shutil.copy(source_path, dest_name)
+
+        toc_file = toctree(
+            current.path_list,
+            new_subdirs,
+            files_for_toc,
+            maxtocdepth,
+            root_path,
+            dir_display_name_converter=dir_display_name_converter,
+        )
+        # Check to see if we are at the last item to be processed
+        # (which has already been popped)
+        # to write the asked for master TOC file name.
+        if not work_to_do:
+            toc_filename = top_level_toc_filename
+        else:
+            toc_filename = output_path / make_flat_name(current.path_list, is_dir=True)
+        toc_file.write_to_file(toc_filename)
 
     if step_glossary_name:
         glossary_filename = output_path / f"{step_glossary_name}.rst"

--- a/sphinx_gherkindoc/writer.py
+++ b/sphinx_gherkindoc/writer.py
@@ -364,7 +364,11 @@ def feature_to_rst(
     feature = feature_class(root_path, source_path)
 
     included_scenarios = get_all_included_scenarios(feature, include_tags, exclude_tags)
-    if not included_scenarios:
+    # In the event of a feature existing,
+    # but not having scenarios in it,
+    # only exclude the feature (and its description, etc)
+    # if include/exclude logic has been activated.
+    if not included_scenarios and (include_tags or exclude_tags):
         return None
 
     section(1, feature)


### PR DESCRIPTION
Fixes #43 

Some details for the issue are in well, the linked issue. The solution here is basically to wait to create the toc tree file until we know which feature rst files are actually created. Then the toc tree can match what is there.

One side effect of the recent changes in 3.5.0 (#40) is that if a feature file exists, but does not have any scenarios in it, it will be excluded. That happens even if you aren't using the new flags `--include-tags` or `--exclude-tags`. My feeling is that it is odd to have a feature file with no scenarios, but if it does exist, we probably should at least document the feature part. So in the 2nd commit, I added that logic to make sure the 3.4.* default logic is reinstated. There could be an argument for _not_ having the last commit, so let me know if we need to figure that out.

One big thing for this PR is that we don't currently have any tests for the `cli.py` logic. That would involve more of an end to end test. Rather than adding all that new test setup in (not sure how easy/difficult it will be), I prioritized fixing the bug. I manually tested this in my environment and it fixes the toc tree issue. I'd like for the reviewers to test in their respective environments as well to make sure it is good. I wouldn't mind a FF to add in tests, but again I'm not sure how much work that will be.