### PR TITLE
Update for changes in new versions of pytest-bdd

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,7 +4,7 @@ on:
     branches: [master]
 jobs:
   publish-docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.6.15
 
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v1

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -6,12 +6,12 @@ jobs:
   publish-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.6.15
 
@@ -19,7 +19,7 @@ jobs:
         uses: ts-graphviz/setup-graphviz@v1
 
       - name: Install Poetry
-        run: pip install poetry
+        run: pip install poetry==1.1.15
 
       - name: Cache Poetry virtualenv
         uses: actions/cache@v2

--- a/.github/workflows/publish-library.yml
+++ b/.github/workflows/publish-library.yml
@@ -4,7 +4,7 @@ on:
     branches: [master]
 jobs:
   publish-library:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/publish-library.yml
+++ b/.github/workflows/publish-library.yml
@@ -6,17 +6,17 @@ jobs:
   publish-library:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.6.15
 
       - name: Install Poetry
-        run: pip install poetry
+        run: pip install poetry==1.1.15
 
       - name: Cache Poetry virtualenv
         uses: actions/cache@v2

--- a/.github/workflows/publish-library.yml
+++ b/.github/workflows/publish-library.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.6.15
 
       - name: Install Poetry
         run: pip install poetry

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -6,12 +6,12 @@ jobs:
   pr-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.6.15
 
@@ -19,7 +19,7 @@ jobs:
         uses: ts-graphviz/setup-graphviz@v1
 
       - name: Install Poetry
-        run: pip install poetry
+        run: pip install poetry==1.1.15
 
       - name: Cache Poetry virtualenv
         uses: actions/cache@v2

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   pr-checks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.6.15
 
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
       hooks:
           - id: black
             language_version: python3
-    - repo: https://gitlab.com/pycqa/flake8
+    - repo: https://github.com/pycqa/flake8
       rev: 3.8.3
       hooks:
           - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
     - repo: https://github.com/ambv/black
-      rev: stable
+      rev: 21.12b0
       hooks:
           - id: black
             language_version: python3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sphinx_gherkindoc"
-version = "3.6.2"
+version = "3.6.3"
 description = "A tool to convert Gherkin into Sphinx documentation"
 authors = ["Lewis Franklin <lewis.franklin@gmail.com>", "Doug Philips <dgou@mac.com>"]
 readme = "README.rst"

--- a/sphinx_gherkindoc/parsers/pytest_bdd.py
+++ b/sphinx_gherkindoc/parsers/pytest_bdd.py
@@ -2,6 +2,8 @@
 from collections import namedtuple
 from typing import List, Optional, Union
 import pathlib
+import importlib.metadata
+import packaging
 
 import pytest_bdd.feature
 
@@ -133,9 +135,16 @@ class Feature(PytestModel):
     """Feature model for Pytest-Bdd."""
 
     def __init__(self, root_path: str, source_path: str):
-        self._data = pytest_bdd.feature.Feature(
-            root_path, pathlib.Path(source_path).resolve().relative_to(root_path)
-        )
+        pytest_bdd_version = packaging.version.parse(importlib.metadata.version("pytest-bdd"))
+
+        if pytest_bdd_version >= packaging.version.parse("4.0.2"):
+            self._data = pytest_bdd.feature.parse_feature(
+                root_path, pathlib.Path(source_path).resolve().relative_to(root_path)
+            )
+        else:
+            self._data = pytest_bdd.feature.Feature(
+                root_path, pathlib.Path(source_path).resolve().relative_to(root_path)
+            )
 
     @property
     def scenarios(self) -> List[Scenario]:

--- a/sphinx_gherkindoc/parsers/pytest_bdd.py
+++ b/sphinx_gherkindoc/parsers/pytest_bdd.py
@@ -30,9 +30,10 @@ class PytestModel(BaseModel):
         keyword = getattr(
             self._data, "keyword", self._data.__class__.__name__.rsplit(".", 1)[-1]
         )
-        if keyword == "Scenario" and self._data.examples.examples:
-            return "Scenario Outline"
-        elif keyword == "ScenarioTemplate":
+        # Match Scenario or ScenarioTemplate
+        if keyword.startswith("Scenario"):
+            if self._data.examples.examples:
+                return "Scenario Outline"
             return "Scenario"
         return keyword
 

--- a/sphinx_gherkindoc/parsers/pytest_bdd.py
+++ b/sphinx_gherkindoc/parsers/pytest_bdd.py
@@ -133,6 +133,7 @@ class Feature(PytestModel):
     """Feature model for Pytest-Bdd."""
 
     def __init__(self, root_path: str, source_path: str):
+        print(f"Parsing: {pathlib.Path(source_path).resolve().relative_to(root_path)}")
         # If the version of pytest-bdd implements the parse_feature method then use it
         pytest_bdd_parse_feature = getattr(pytest_bdd.feature, "parse_feature", None)
         if callable(pytest_bdd_parse_feature):

--- a/sphinx_gherkindoc/parsers/pytest_bdd.py
+++ b/sphinx_gherkindoc/parsers/pytest_bdd.py
@@ -32,6 +32,8 @@ class PytestModel(BaseModel):
         )
         if keyword == "Scenario" and self._data.examples.examples:
             return "Scenario Outline"
+        elif keyword == "ScenarioTemplate":
+            return "Scenario"
         return keyword
 
     @property

--- a/sphinx_gherkindoc/parsers/pytest_bdd.py
+++ b/sphinx_gherkindoc/parsers/pytest_bdd.py
@@ -1,9 +1,9 @@
 """Helper functions for writing rST files."""
 from collections import namedtuple
+from packaging import version
 from typing import List, Optional, Union
-import pathlib
 import importlib.metadata
-import packaging
+import pathlib
 
 import pytest_bdd.feature
 
@@ -135,9 +135,9 @@ class Feature(PytestModel):
     """Feature model for Pytest-Bdd."""
 
     def __init__(self, root_path: str, source_path: str):
-        pytest_bdd_version = packaging.version.parse(importlib.metadata.version("pytest-bdd"))
+        pytest_bdd_version = version.parse(importlib.metadata.version("pytest-bdd"))
 
-        if pytest_bdd_version >= packaging.version.parse("4.0.2"):
+        if pytest_bdd_version >= version.parse("4.0.2"):
             self._data = pytest_bdd.feature.parse_feature(
                 root_path, pathlib.Path(source_path).resolve().relative_to(root_path)
             )

--- a/sphinx_gherkindoc/parsers/pytest_bdd.py
+++ b/sphinx_gherkindoc/parsers/pytest_bdd.py
@@ -146,11 +146,11 @@ class Feature(PytestModel):
                     root_path, relative_file_path
                 )
             else:
-                self._data = pytest_bdd.feature.Feature(
-                    root_path, relative_file_path
-                )
+                self._data = pytest_bdd.feature.Feature(root_path, relative_file_path)
         except Exception as e:
-            raise ValueError(f"Failed to parse feature file: {relative_file_path}") from e
+            raise ValueError(
+                f"Failed to parse feature file: {relative_file_path}"
+            ) from e
 
     @property
     def scenarios(self) -> List[Scenario]:

--- a/sphinx_gherkindoc/parsers/pytest_bdd.py
+++ b/sphinx_gherkindoc/parsers/pytest_bdd.py
@@ -133,17 +133,22 @@ class Feature(PytestModel):
     """Feature model for Pytest-Bdd."""
 
     def __init__(self, root_path: str, source_path: str):
-        print(f"Parsing: {pathlib.Path(source_path).resolve().relative_to(root_path)}")
+        relative_file_path = pathlib.Path(source_path).resolve().relative_to(root_path)
+
         # If the version of pytest-bdd implements the parse_feature method then use it
         pytest_bdd_parse_feature = getattr(pytest_bdd.feature, "parse_feature", None)
-        if callable(pytest_bdd_parse_feature):
-            self._data = pytest_bdd.feature.parse_feature(
-                root_path, pathlib.Path(source_path).resolve().relative_to(root_path)
-            )
-        else:
-            self._data = pytest_bdd.feature.Feature(
-                root_path, pathlib.Path(source_path).resolve().relative_to(root_path)
-            )
+        try:
+            if callable(pytest_bdd_parse_feature):
+                self._data = pytest_bdd.feature.parse_feature(
+                    root_path, relative_file_path
+                )
+            else:
+                self._data = pytest_bdd.feature.Feature(
+                    root_path, relative_file_path
+                )
+        except:
+            print(f"Failed to parse feature file: {relative_file_path}")
+            raise
 
     @property
     def scenarios(self) -> List[Scenario]:

--- a/sphinx_gherkindoc/parsers/pytest_bdd.py
+++ b/sphinx_gherkindoc/parsers/pytest_bdd.py
@@ -135,14 +135,14 @@ class Feature(PytestModel):
     """Feature model for Pytest-Bdd."""
 
     def __init__(self, root_path: str, source_path: str):
-        pytest_bdd_version = version.parse(importlib.metadata.version("pytest-bdd"))
+        self.pytest_bdd_version = version.parse(importlib.metadata.version("pytest-bdd"))
 
-        if pytest_bdd_version >= version.parse("4.0.2"):
-            self._data = pytest_bdd.feature.parse_feature(
+        if self.pytest_bdd_version < version.parse("4.0.2"):
+            self._data = pytest_bdd.feature.Feature(
                 root_path, pathlib.Path(source_path).resolve().relative_to(root_path)
             )
         else:
-            self._data = pytest_bdd.feature.Feature(
+            self._data = pytest_bdd.feature.parse_feature(
                 root_path, pathlib.Path(source_path).resolve().relative_to(root_path)
             )
 
@@ -160,6 +160,6 @@ class Feature(PytestModel):
     @property
     def examples(self) -> List[Optional[Example]]:
         """Return feature-level examples, if any exist."""
-        if self._data.examples.examples:
+        if self.pytest_bdd_version < version.parse("4.0.2") and self._data.examples.examples:
             return [Example(self._data.examples)]
         return []

--- a/sphinx_gherkindoc/parsers/pytest_bdd.py
+++ b/sphinx_gherkindoc/parsers/pytest_bdd.py
@@ -149,9 +149,8 @@ class Feature(PytestModel):
                 self._data = pytest_bdd.feature.Feature(
                     root_path, relative_file_path
                 )
-        except:
-            print(f"Failed to parse feature file: {relative_file_path}")
-            raise
+        except Exception as e:
+            raise ValueError(f"Failed to parse feature file: {relative_file_path}") from e
 
     @property
     def scenarios(self) -> List[Scenario]:


### PR DESCRIPTION
pytest-bdd changed how Features and Scenarios are parsed.

1. Features no longer do the parsing, so call the `parse_feature` function if it exists instead.
2. Features can no longer have examples, so check if the object has the examples attribute before trying to access it.
3. If there are feature file parsing exceptions, report the feature file that failed to parse.
4. Scenarios are initially parsed into a `ScenarioTemplate` which get turned into Scenarios and Scenario Outlines, so change the keyword for `ScenarioTemplate` to the appropriate form. 